### PR TITLE
shorten payloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,4 +43,3 @@ stages:
         - controlFileName: 'control'
           payloadMaps:
             - installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\National Instruments'
-              payloadLocation: 'Built'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-telemetry-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
